### PR TITLE
fix Wellcome compliance calculation - Author Manuscript info never taken into account, always undefined by mistake

### DIFF
--- a/apps/clapi/server/endpoints/service/lantern.js
+++ b/apps/clapi/server/endpoints/service/lantern.js
@@ -1188,7 +1188,6 @@ var _formatwellcome = function(result) {
   } else {
     result['Author Manuscript?'] = "FALSE";
   }
-  delete result.is_aam;
   if (result.aheadofprint === false) {
     result['Ahead of Print?'] = 'FALSE';
   } else if (result.aheadofprint) {
@@ -1206,6 +1205,8 @@ var _formatwellcome = function(result) {
   if (result.in_epmc && (result.is_aam || epmc_lics)) result['Standard Compliance?'] = 'TRUE';
   if (result.in_epmc && result.is_aam) result['Deluxe Compliance?'] = 'TRUE';
   if (result.in_epmc && epmc_lics && result.is_oa) result['Deluxe Compliance?'] = 'TRUE';
+  delete result.is_aam;
+
   if ( result.provenance ) {
     result['Compliance Processing Output'] = '';
     var fst = true;


### PR DESCRIPTION
A bugfix, only affecting wellcome output formatting. A variable (is_aam) was being cleaned from the result object too early, resulting in it always being undefined when used for compliance calc.
