### PR TITLE
Feature/fix urlmatch licence detection

### DIFF
--- a/apps/clapi/server/endpoints/academic/licence.js
+++ b/apps/clapi/server/endpoints/academic/licence.js
@@ -101,7 +101,7 @@ CLapi.internals.academic.licence = function(url,resolve,content,start,end,refres
           // This is an Open Access article distributed under the terms of the Creative Commons Attribution License (<a href="http://creativecommons.org/licenses/by/2.0" ref="reftype=extlink&amp;article-id=2210051&amp;issue-id=73721&amp;journal-id=906&amp;FROM=Article%7CFront%20Matter&amp;TO=External%7CLink%7CURI&amp;rendering-type=normal" target="pmc_ext">http://creativecommons.org/licenses/by/2.0</a>), which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.
           var match = m.toLowerCase().replace(/[^a-z0-9]/g, '');
           var urlmatch = m.indexOf('://') !== -1 ? m.toLowerCase().split('://')[1].split('"')[0].split(' ')[0] : false;
-          if (urlmatch && content.indexOf(urlmatch) !== -1) {
+          if (urlmatch && content.toLowerCase().indexOf(urlmatch) !== -1) {
             console.log('academic licence matched on url ' + urlmatch);
             lic.licence = l;
             lic.matched = urlmatch;
@@ -147,6 +147,7 @@ CLapi.internals.academic.licence = function(url,resolve,content,start,end,refres
       // yes, there is a meteor call that is sync, but it is not returning here properly for some reason
       Meteor.http.call('GET',resolved, function(err,res) { // this shuold perhaps become a phantomjs render
         if (err) {
+          console.log('Error while fetching ' + resolved + ' for academic licence check.');
           return callback(null,{retrievable:false});
         } else {
           var lic = findlicences(res.content,resolved);

--- a/apps/clapi/server/endpoints/service/lantern.js
+++ b/apps/clapi/server/endpoints/service/lantern.js
@@ -774,7 +774,7 @@ CLapi.internals.service.lantern.process = function(processid) {
       var extrainfo = '';
       if (lic.matched) {extrainfo += ' The bit that let us determine the licence was: ' + lic.matched + ' .';}
       if (lic.matcher) {extrainfo += ' If licence statements contain URLs we will try to find those in addition to ' +
-        'searching for the statement\'s text. Here the entire licence statement was: ' + lic.matched + ' .';}
+        'searching for the statement\'s text. Here the entire licence statement was: ' + lic.matcher + ' .';}
       result.provenance.push('Added EPMC licence from ' + lic.source + '.' + extrainfo);
 
       // result.licence and result.licence_source can be overwritten later by

--- a/apps/clapi/server/endpoints/use/europepmc.js
+++ b/apps/clapi/server/endpoints/use/europepmc.js
@@ -236,9 +236,10 @@ CLapi.internals.use.europepmc.licence = function(pmcid,rec,fulltext) {
     if (pmcid) {
       var normalised_pmcid = 'PMC' + pmcid.toLowerCase().replace('pmc','');
       var licsplash = CLapi.internals.academic.licence('http://europepmc.org/articles/' + normalised_pmcid,false,undefined,undefined,undefined,true);
-      // console.log(pmcid + ' licsplash HTML check' + licsplash);
+      // console.log(pmcid + ' licsplash HTML check on http://europepmc.org/articles/' + normalised_pmcid);
+      // console.log(licsplash);
       if (licsplash.licence && licsplash.licence !== 'unknown') {
-        // console.log(pmcid + ' licsplash HTML check success' + licsplash.licence);
+        // console.log(pmcid + ' licsplash HTML check success ' + licsplash.licence);
         return {licence:licsplash.licence,source:'epmc_html',
           matcher: licsplash.matcher ? licsplash.matcher : undefined,
           matched: licsplash.matched ? licsplash.matched : undefined


### PR DESCRIPTION
Affects Lantern as well, but seems like a straightforward fix to do. The page content for licence detection is lowercased in case we're trying a text match, but not if we're trying a URL match. Yet the matching piece (the url) itself _is_ lowercased.
