### PR TITLE
Author manuscript - allow for errors and record appropriate notes

### DIFF
--- a/apps/clapi/server/endpoints/service/lantern.js
+++ b/apps/clapi/server/endpoints/service/lantern.js
@@ -855,8 +855,11 @@ CLapi.internals.service.lantern.process = function(processid) {
     if (!ft_envelope.fulltext && result.pmcid) ft_envelope = CLapi.internals.use.europepmc.fulltextXML(result.pmcid);
 
     if(ft_envelope.error) {
-      if (ft_envelope.error === 'NOT_FOUND_IN_EPMC') result.provenance.push('Not found in EUPMC when trying to fetch full text XML.');
-      if (ft_envelope.error === 'EPMC_ERROR') result.provenance.push('Encountered an error while retrieving the EUPMC full text XML. One possible reason is EUPMC being temporarily unavailable.');
+      if (ft_envelope.error == 404) {
+        result.provenance.push('Not found in EUPMC when trying to fetch full text XML.');
+      } else {
+        result.provenance.push('Encountered an error while retrieving the EUPMC full text XML. One possible reason is EUPMC being temporarily unavailable.');
+      }
     }
     
     var ft = ft_envelope.fulltext;

--- a/apps/clapi/server/endpoints/use/europepmc.js
+++ b/apps/clapi/server/endpoints/use/europepmc.js
@@ -65,11 +65,10 @@ CLapi.addRoute('use/europepmc/pmc/:qry/fulltext', {
       var ft_envelope;
       ft_envelope = CLapi.internals.use.europepmc.fulltextXML(this.urlParams.qry);
       if(ft_envelope.error) {
-        if (ft_envelope.error === 'NOT_FOUND_IN_EPMC') {
+        if (ft_envelope.error == 404) {
           console.log(this.urlParams.qry + ' not found when fetching EPMC full text XML.');
           return {statusCode: 404, body: {status: 'error', data: '404 not found. Not found in EPMC.' }};
-        }
-        if (ft_envelope.error === 'EPMC_ERROR') {
+        } else {
           console.log('Error while fetching EPMC full text XML for ' + this.urlParams.qry + '. Most probably EPMC is temporarily down.');
           return {statusCode: 404, body: {status: 'error', data: '404 not found. Error when getting from EPMC.'}};
         }
@@ -356,11 +355,7 @@ CLapi.internals.use.europepmc.fulltextXML = function(pmcid,rec) {
     var r = Meteor.http.call('GET', url);
     if (r.statusCode === 200) result.fulltext = r.content;
   } catch(err) {
-    if(err.response.statusCode === 404) {
-      result.error = 'NOT_FOUND_IN_EPMC';
-    } else {
-      result.error = 'EPMC_ERROR';
-    }
+    result.error = err.response.statusCode;
   }
   return result;
 }

--- a/apps/clapi/server/endpoints/use/europepmc.js
+++ b/apps/clapi/server/endpoints/use/europepmc.js
@@ -340,9 +340,6 @@ CLapi.internals.use.europepmc.authorManuscript = function(pmcid,rec,fulltext) {
 }
 
 CLapi.internals.use.europepmc.fulltextXML = function(pmcid,rec) {
-  // This function will raise an error if the HTTP GET returns an HTTP error like 404
-  // When using it, make sure to put it in a try/catch block and take appropriate
-  // action on error, like adding processing notes, logging and setting values to "unknown".
   var res;
   if (pmcid && !rec) res = CLapi.internals.use.europepmc.search('PMC' + pmcid.toLowerCase().replace('pmc',''));
   if (res && res.total > 0) rec = res.data[0];

--- a/apps/clapi/server/endpoints/use/europepmc.js
+++ b/apps/clapi/server/endpoints/use/europepmc.js
@@ -76,9 +76,9 @@ CLapi.addRoute('use/europepmc/pmc/:qry/fulltext', {
       }
       this.response.writeHead(200, {
         'Content-type': 'application/xml',
-        'Content-length': res.length
+        'Content-length': ft_envelope.fulltext.length
       });
-      this.response.write(res);
+      this.response.write(ft_envelope.fulltext);
       this.done();
       return {};
     }

--- a/apps/clapi/server/endpoints/use/europepmc.js
+++ b/apps/clapi/server/endpoints/use/europepmc.js
@@ -288,12 +288,15 @@ CLapi.internals.use.europepmc.authorManuscript = function(pmcid,rec,fulltext) {
   if (res && res.total > 0 || rec || fulltext) {
     if (!rec) rec = res.data[0];
     if (!pmcid && rec) pmcid = rec.pmcid;
+    var ft_arg_checked = false;
     if (fulltext) {
       if (fulltext.indexOf('pub-id-type=\'manuscript\'') !== -1) {
         // console.log("First call for AAM XML");
+        // ft_arg_checked = true;  // technically true but not necessary since we return
         return 'Y_IN_EPMC_FULLTEXT';
       } else {
-        return false;
+        // so far AAM is false
+        ft_arg_checked = true;  // but don't return yet - in case both pmcid and fulltext args are passed in, we should try using the pmcid next before deciding "false"
       }
     }
     
@@ -332,9 +335,11 @@ CLapi.internals.use.europepmc.authorManuscript = function(pmcid,rec,fulltext) {
         }
       }
     } else {
+      if (ft_arg_checked) return false;
       return 'unknown';
     }
   } else {
+    if (ft_arg_checked) return false;
     return 'unknown';
   }
 }


### PR DESCRIPTION
This is tested - the errors do appear correctly. Tested by pointing europepmc.org and ebi.ac.uk to 127.0.0.1 and setting my local nginx to return 500 for those server names.

Here is a file showing what it looks like with EPMC _enabled_ (so the usual case 99% of the time) - so you can see there's no ill effects there.

[author_manuscript_test_results.csv.zip](https://github.com/CottageLabs/api/files/432192/author_manuscript_test_results.csv.zip)
