### PR TITLE
stop using xml2txt until an alternative is found, it is affecting too many licences

### DIFF
--- a/apps/clapi/server/endpoints/academic/licence.js
+++ b/apps/clapi/server/endpoints/academic/licence.js
@@ -88,7 +88,8 @@ CLapi.internals.academic.licence = function(url,resolve,content,start,end,refres
     
     var text;
     try {
-      text = CLapi.internals.convert.xml2txt(undefined,content).toLowerCase().replace(/[^a-z0-9]/g,'');
+      // text = CLapi.internals.convert.xml2txt(undefined,content).toLowerCase().replace(/[^a-z0-9]/g,'');  / seems to munge up the XML somehow, TODO alternative xml2txt
+      text = content.toLowerCase().replace(/[^a-z0-9]/g,'');
     } catch(err) {}
     if (text) {
       for ( var i in licences ) {


### PR DESCRIPTION
See http://github.com/CottageLabs/LanternPM/issues/114 for details (and now the extra detail that xml2txt appears to just silently swallow all the content on occasion - though appears to be doing it quite a lot on live).

This is a really simplistic approach, but on the other hand it should be quite good at detecting licences. I also don't think leaving the XML tags in will result in an increase in false positives - licence statements are rarely similar to XML tags. I can't see any significant drawbacks to doing this simple approach.

Note this is affecting HTML licence detection as well, since xml2txt is invoked for HTML too. In previous cases it appeared to leave the HTML untouched while munging the XML. But now for this article (and others):

```
PMCID,PMID
PMC4936516,27398388
```

it actually just returns `null` when both XML and HTML pass through it, effectively disabling all licence detection.

I've been getting grilled by Wellcome all week about it and thought the recent EPMC downtime might be responsible, but it isn't, this reproducibly doesn't work for a large number of articles while EPMC is up and has the right data.
