### PR TITLE
detect author manuscript from XML even if related attr val uses double quotes

### DIFF
--- a/apps/clapi/server/endpoints/use/europepmc.js
+++ b/apps/clapi/server/endpoints/use/europepmc.js
@@ -289,7 +289,7 @@ CLapi.internals.use.europepmc.authorManuscript = function(pmcid,rec,fulltext) {
     if (!pmcid && rec) pmcid = rec.pmcid;
     var ft_arg_checked = false;
     if (fulltext) {
-      if (fulltext.indexOf('pub-id-type=\'manuscript\'') !== -1) {
+      if (fulltext.indexOf('pub-id-type=\'manuscript\'') !== -1 && fulltext.indexOf('pub-id-type="manuscript"') !== -1) {
         // console.log("First call for AAM XML");
         // ft_arg_checked = true;  // technically true but not necessary since we return
         return 'Y_IN_EPMC_FULLTEXT';
@@ -302,7 +302,7 @@ CLapi.internals.use.europepmc.authorManuscript = function(pmcid,rec,fulltext) {
     if ( pmcid ) {
       var ft = CLapi.internals.use.europepmc.fulltextXML(pmcid).fulltext;
 
-      if (ft && ft.indexOf('pub-id-type=\'manuscript\'') !== -1) {
+      if (ft && ft.indexOf('pub-id-type=\'manuscript\'') !== -1 && fulltext.indexOf('pub-id-type="manuscript"') !== -1) {
         // console.log("Different call for AAM XML");
         return 'Y_IN_EPMC_FULLTEXT';
       } else {


### PR DESCRIPTION
Fixes https://github.com/CottageLabs/LanternPM/issues/120

Verified this is the problem indeed by going to

and running in the browser console:

``` javascript
var markup = document.documentElement.innerHTML;
markup.indexOf('pub-id-type=\'manuscript\'')  // current check: returns -1
markup.indexOf('pub-id-type="manuscript"')  // proposed additional check: returns 2416
```
